### PR TITLE
Automatically deploy Win installer to GitHub Releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,13 +42,13 @@ build_script:
   - ps: Get-ChildItem .\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   #- appveyor PushArtifact PETPVC-1.0.0-win32.exe
 
- deploy:
-     provider: GitHub
-     auth_token:
-         secure: jQkp3YvSjfaSMMSh8XqUZfGKsztNVsuSgrmxxm9cpU3hpNfup9b8+7yhajzbNfb9
-     artifact: /.*\.exe/
-     on:
-         branch: master
+deploy:
+  - provider: GitHub
+    auth_token:
+        secure: jQkp3YvSjfaSMMSh8XqUZfGKsztNVsuSgrmxxm9cpU3hpNfup9b8+7yhajzbNfb9
+    artifact: /.*\.exe/
+    on:
+        branch: master
 
 #artifacts:
 # path: bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,16 @@ build_script:
   - msbuild RUN_TESTS.vcxproj
   - msbuild PACKAGE.vcxproj
   - ps: Get-ChildItem .\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq "true")
+      {
+        Update-AppveyorBuild -Version "$env:APPVEYOR_REPO_TAG_NAME"
+      }
+      else
+      {
+        Update-AppveyorBuild -Version "dev-$($env:APPVEYOR_REPO_COMMIT.substring(0,7))"
+      }
+
   #- appveyor PushArtifact PETPVC-1.0.0-win32.exe
 
 deploy:
@@ -52,6 +62,7 @@ deploy:
     draft: true
     on:
         branch: master
+        appveyor_repo_tag: true
 
 #artifacts:
 # path: bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   ITKSRC: C:\projects\deps\ITK
   ITKINSTALL: C:\projects\deps\ITK-4.10.1
   ITKBUILD: C:\projects\deps\ITK-BUILD
-    
+
 install:
   - IF NOT EXIST C:\projects\deps mkdir C:\projects\deps
   - cd C:\projects\deps
@@ -37,10 +37,18 @@ build_script:
   - cd C:\projects\PETPVC
   - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%ITKINSTALL% -DCMAKE_INSTALL_PATH=. .
   - msbuild INSTALL.vcxproj
-  - msbuild RUN_TESTS.vcxproj 
+  - msbuild RUN_TESTS.vcxproj
   - msbuild PACKAGE.vcxproj
   - ps: Get-ChildItem .\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   #- appveyor PushArtifact PETPVC-1.0.0-win32.exe
+
+ deploy:
+     provider: GitHub
+     auth_token:
+         secure: jQkp3YvSjfaSMMSh8XqUZfGKsztNVsuSgrmxxm9cpU3hpNfup9b8+7yhajzbNfb9
+     artifact: /.*\.exe/
+     on:
+         branch: master
 
 #artifacts:
 # path: bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ deploy:
   - provider: GitHub
     auth_token:
         secure: jQkp3YvSjfaSMMSh8XqUZfGKsztNVsuSgrmxxm9cpU3hpNfup9b8+7yhajzbNfb9
-    release: win32-v$(appveyor_repo_tag)
+    release: win32-v$(appveyor_build_version)
     description: 'Windows release'
     artifact: /.*\.exe/
     draft: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ deploy:
   - provider: GitHub
     auth_token:
         secure: jQkp3YvSjfaSMMSh8XqUZfGKsztNVsuSgrmxxm9cpU3hpNfup9b8+7yhajzbNfb9
-    release: win32-v$(appveyor_build_version)
+    release: win32-$(appveyor_build_version)
     description: 'Windows release'
     artifact: /.*\.exe/
     draft: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,10 @@ deploy:
   - provider: GitHub
     auth_token:
         secure: jQkp3YvSjfaSMMSh8XqUZfGKsztNVsuSgrmxxm9cpU3hpNfup9b8+7yhajzbNfb9
+    release: win32-v$(appveyor_repo_tag)
+    description: 'Windows release'
     artifact: /.*\.exe/
+    draft: true
     on:
         branch: master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ deploy:
     draft: true
     on:
         branch: master
-        appveyor_repo_tag: true
+        appveyor_repo_tag: false
 
 #artifacts:
 # path: bin


### PR DESCRIPTION
On successful build, push win32 installer to GitHub Releases. Initially it is a draft, so needs approval before being publicly visible. 