### PR TITLE
Option to disable non-negativity for VC (#56).

### DIFF
--- a/lib/petpvcIntraRegVCImageFilter.h
+++ b/lib/petpvcIntraRegVCImageFilter.h
@@ -3,7 +3,7 @@
 
    Author:      Benjamin A. Thomas
 
-   Copyright 2015 Institute of Nuclear Medicine, University College London.
+   Copyright 2015-2019 Institute of Nuclear Medicine, University College London.
    Copyright 2015 Clinical Imaging Research Centre, A*STAR-NUS.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -130,6 +130,9 @@ public:
         this->m_bVerbose = bVerbose;
     }
 
+    void SetDisableNonNegativity( bool bDisableNonNeg ) {
+        this->m_bDisableNonNeg = bDisableNonNeg;
+    }
 
 protected:
     IntraRegVCImageFilter();
@@ -143,6 +146,7 @@ protected:
     float m_fAlpha;
     float m_fStopCriterion;
     bool m_bVerbose;
+    bool m_bDisableNonNeg;
 
 private:
     IntraRegVCImageFilter(const Self &); //purposely not implemented

--- a/lib/petpvcIntraRegVCImageFilter.txx
+++ b/lib/petpvcIntraRegVCImageFilter.txx
@@ -3,7 +3,7 @@
 
    Author:      Benjamin A. Thomas
 
-   Copyright 2015 Institute of Nuclear Medicine, University College London.
+   Copyright 2015-2019 Institute of Nuclear Medicine, University College London.
    Copyright 2015 Clinical Imaging Research Centre, A*STAR-NUS.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,6 +39,7 @@ IntraRegVCImageFilter< TInputImage, TMaskImage>
 {
     this->m_nIterations = 10;
     this->m_bVerbose = false;
+    this->m_bDisableNonNeg = false;
 }
 
 template< class TInputImage, class TMaskImage >
@@ -171,8 +172,16 @@ void IntraRegVCImageFilter< TInputImage, TMaskImage>
             multiplyFilter->SetInput( blurFilter2->GetOutput() );
             addFilter->SetInput1( imageEstimate );
             addFilter->SetInput2( multiplyFilter->GetOutput() );
-            thresholdFilter->SetInput( addFilter->GetOutput() );  
-            thresholdFilter->Update();
+
+            if (!m_bDisableNonNeg) {
+                thresholdFilter->SetInput( addFilter->GetOutput() );  
+                thresholdFilter->Update();
+                imageEstimate = thresholdFilter->GetOutput();
+            }
+            else {
+                addFilter->Update();
+                imageEstimate = addFilter->GetOutput();
+            }
 
             imageEstimate = thresholdFilter->GetOutput();
             imageEstimate->DisconnectPipeline();

--- a/lib/petpvcVanCittertPVCImageFilter.h
+++ b/lib/petpvcVanCittertPVCImageFilter.h
@@ -3,7 +3,7 @@
 
    Author:      Benjamin A. Thomas
 
-   Copyright 2015 Institute of Nuclear Medicine, University College London.
+   Copyright 2015-2019 Institute of Nuclear Medicine, University College London.
    Copyright 2015 Clinical Imaging Research Centre, A*STAR-NUS.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -109,6 +109,10 @@ public:
         this->m_bVerbose = bVerbose;
     }
 
+    void SetDisableNonNegativity( bool bDisableNonNeg ) {
+        this->m_bDisableNonNeg = bDisableNonNeg;
+    }
+
 
 protected:
     VanCittertPVCImageFilter();
@@ -122,6 +126,7 @@ protected:
     float m_fAlpha;
     float m_fStopCriterion;
     bool m_bVerbose;
+    bool m_bDisableNonNeg;
 
 private:
     VanCittertPVCImageFilter(const Self &); //purposely not implemented

--- a/lib/petpvcVanCittertPVCImageFilter.txx
+++ b/lib/petpvcVanCittertPVCImageFilter.txx
@@ -3,7 +3,7 @@
 
    Author:      Benjamin A. Thomas
 
-   Copyright 2015 Institute of Nuclear Medicine, University College London.
+   Copyright 2015-2019 Institute of Nuclear Medicine, University College London.
    Copyright 2015 Clinical Imaging Research Centre, A*STAR-NUS.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +41,7 @@ VanCittertPVCImageFilter< TInputImage >
     this->m_bVerbose = false;
     this->m_fAlpha = 1.5;
     this->m_fStopCriterion = 0.01;
+    this->m_bDisableNonNeg = false;
 }
 
 template< class TInputImage >
@@ -116,10 +117,17 @@ void VanCittertPVCImageFilter< TInputImage >
             multiplyFilter->SetInput( blurFilter2->GetOutput() );
             addFilter->SetInput1( imageEstimate );
             addFilter->SetInput2( multiplyFilter->GetOutput() );
-            thresholdFilter->SetInput( addFilter->GetOutput() );  
-            thresholdFilter->Update();
+            
+            if (!m_bDisableNonNeg) {
+                thresholdFilter->SetInput( addFilter->GetOutput() );  
+                thresholdFilter->Update();
+                imageEstimate = thresholdFilter->GetOutput();
+            }
+            else {
+                addFilter->Update();
+                imageEstimate = addFilter->GetOutput();
+            }
 
-            imageEstimate = thresholdFilter->GetOutput();
             imageEstimate->DisconnectPipeline();
             
             ConstImageIterator currIt( imageEstimate, imageEstimate->GetLargestPossibleRegion() );

--- a/src/PETPVC.cxx
+++ b/src/PETPVC.cxx
@@ -3,6 +3,7 @@
 
    Author:      Benjamin A. Thomas
 
+   Copyright 2019 Institute of Nuclear Medicine, University College London.
    Copyright 2015 Clinical Imaging Research Centre, A*STAR-NUS.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -147,6 +148,9 @@ int main(int argc, char *argv[])
     command.SetOptionLongTag("Stop", "stop");
     command.AddOptionField("Stop", "stopval", MetaCommand::FLOAT, false, "0.01");
 
+	command.SetOption("NonNeg", "0", false,"Turns off non-negativity constraint");
+    command.SetOptionLongTag("NonNeg", "disable-non-neg");
+
     //Parse command line.
     if (!command.Parse(argc, argv)) {
 		printPVCMethodList();
@@ -267,6 +271,10 @@ int main(int argc, char *argv[])
     			//Get value for stopping criterion.
 			    float fStop = command.GetValueAsFloat("Stop", "stopval");
 		    	vcFilter->SetStoppingCond( fStop );
+
+				//Toggle non-negativity constraint for VC
+    			const bool bDisableNonNeg = command.GetValueAsBool("NonNeg");
+				vcFilter->SetDisableNonNegativity( bDisableNonNeg );
 
 		    	vcFilter->SetVerbose ( bDebug );
 
@@ -576,6 +584,10 @@ int main(int argc, char *argv[])
 			    float fStop = command.GetValueAsFloat("Stop", "stopval");
 		    	vcFilter->SetStoppingCond( fStop );
 
+				//Toggle non-negativity constraint for VC
+    			const bool bDisableNonNeg = command.GetValueAsBool("NonNeg");
+				vcFilter->SetDisableNonNegativity( bDisableNonNeg );
+
 		    	vcFilter->SetVerbose ( bDebug );
 
     			//Perform VC.
@@ -785,6 +797,10 @@ int main(int argc, char *argv[])
 			    float fStop = command.GetValueAsFloat("Stop", "stopval");
 		    	vcFilter->SetStoppingCond( fStop );
 
+				//Toggle non-negativity constraint for VC
+    			const bool bDisableNonNeg = command.GetValueAsBool("NonNeg");
+				vcFilter->SetDisableNonNegativity( bDisableNonNeg );
+
 		    	vcFilter->SetVerbose ( bDebug );
 
     			//Perform VC.
@@ -888,6 +904,10 @@ int main(int argc, char *argv[])
     			//Get value for stopping criterion.
 			    float fStop = command.GetValueAsFloat("Stop", "stopval");
 		    	vcFilter->SetStoppingCond( fStop );
+
+				//Toggle non-negativity constraint for VC
+    			const bool bDisableNonNeg = command.GetValueAsBool("NonNeg");
+				vcFilter->SetDisableNonNegativity( bDisableNonNeg );
 
 		    	vcFilter->SetVerbose ( bDebug );
 
@@ -995,6 +1015,10 @@ int main(int argc, char *argv[])
 			    float fStop = command.GetValueAsFloat("Stop", "stopval");
 		    	vcFilter->SetStoppingCond( fStop );
 
+				//Toggle non-negativity constraint for VC
+    			const bool bDisableNonNeg = command.GetValueAsBool("NonNeg");
+				vcFilter->SetDisableNonNegativity( bDisableNonNeg );
+
 		    	vcFilter->SetVerbose ( bDebug );
 
     			//Perform VC.
@@ -1098,6 +1122,10 @@ int main(int argc, char *argv[])
     			//Get value for stopping criterion.
 			    float fStop = command.GetValueAsFloat("Stop", "stopval");
 		    	vcFilter->SetStoppingCond( fStop );
+
+				//Toggle non-negativity constraint for VC
+    			const bool bDisableNonNeg = command.GetValueAsBool("NonNeg");
+				vcFilter->SetDisableNonNegativity( bDisableNonNeg );
 
 		    	vcFilter->SetVerbose ( bDebug );
 
@@ -1207,6 +1235,10 @@ int main(int argc, char *argv[])
     			//Get value for stopping criterion.
 			    float fStop = command.GetValueAsFloat("Stop", "stopval");
 		    	vcFilter->SetStoppingCond( fStop );
+
+				//Toggle non-negativity constraint for VC
+    			const bool bDisableNonNeg = command.GetValueAsBool("NonNeg");
+				vcFilter->SetDisableNonNegativity( bDisableNonNeg );
 
 		    	vcFilter->SetVerbose ( bDebug );
 

--- a/src/VanCittert.cxx
+++ b/src/VanCittert.cxx
@@ -3,6 +3,7 @@
 
    Author:      Benjamin A. Thomas
 
+   Copyright 2019 Institute of Nuclear Medicine, University College London.
    Copyright 2015 Clinical Imaging Research Centre, A*STAR-NUS.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,6 +100,9 @@ int main(int argc, char *argv[])
     command.SetOptionLongTag("Stop", "stop");
     command.AddOptionField("Stop", "stopval", MetaCommand::FLOAT, false, "0.01");
 
+    command.SetOption("NonNeg", "0", false,"Turns off non-negativity constraint");
+    command.SetOptionLongTag("NonNeg", "disable-non-neg");
+
     command.SetOption("debug", "d", false,"Prints debug information");
     command.SetOptionLongTag("debug", "debug");
 
@@ -134,6 +138,9 @@ int main(int argc, char *argv[])
     //Toggle debug mode
     bool bDebug = command.GetValueAsBool("debug");
 
+    //Toggle non-negativity constraint
+    const bool bDisableNonNeg = command.GetValueAsBool("NonNeg");
+
     //Create reader for PET image.
     PETReaderType::Pointer petReader = PETReaderType::New();
     petReader->SetFileName(sPETFileName);
@@ -166,6 +173,7 @@ int main(int argc, char *argv[])
 	vcFilter->SetAlpha( fAlpha );
     vcFilter->SetStoppingCond( fStop );
     vcFilter->SetVerbose ( bDebug );
+    vcFilter->SetDisableNonNegativity( bDisableNonNeg );
 
     //Perform VC.
     try {


### PR DESCRIPTION
Allows the non-negativity constraint for Van-Cittert to be disabled, if desired, with `--disable-non-neg`. This is available in both `pvc_vc` and `petpvc` applications. Fixes #56 