### PR TITLE
Return EXIT_SUCCESS if no command provided

### DIFF
--- a/src/PETPVC.cxx
+++ b/src/PETPVC.cxx
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
     //Parse command line.
     if (!command.Parse(argc, argv)) {
 		printPVCMethodList();
-        return EXIT_FAILURE;
+		return EXIT_SUCCESS;
     }
 
     //Get image filenames


### PR DESCRIPTION
I would like to use the `petpvc` command without arguments as a test command for the conda-forge package. However, that approach currently fails since not providing any command results in a docstring being printed to stdout and the program exiting with `EXIT_FAILURE`.

I am proposing to return `EXIT_SUCCESS` instead. This behaviour is aligned with modern CLI standards whereby calling an entry point without argument or with `-h` or `--help` should yield a description of the program and exit without errors.

I tried applying this patch to the `conda-forge` build and it works as intended.