### PR TITLE
Fix itkTypeMacro and fuzzyCorrFilter

### DIFF
--- a/lib/petpvcDiscreteIYPVCImageFilter.h
+++ b/lib/petpvcDiscreteIYPVCImageFilter.h
@@ -56,7 +56,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(DiscreteIYPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(DiscreteIYPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcFuzzyCorrectionFilter.h
+++ b/lib/petpvcFuzzyCorrectionFilter.h
@@ -53,7 +53,11 @@ public:
 
     itkNewMacro(Self);
 
-    itkTypeMacro(FuzzyCorrFilter, ImageToImageFilter);
+#if ITK_VERSION_MAJOR < 6
+    itkTypeMacro(FuzzyCorrectionFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(FuzzyCorrectionFilter);
+#endif
 
     //Returns correction factors.
 

--- a/lib/petpvcGTMImageFilter.h
+++ b/lib/petpvcGTMImageFilter.h
@@ -54,7 +54,11 @@ public:
 
     itkNewMacro(Self);
 
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(GTMImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(GTMImageFilter);
+#endif
 
     //Returns correction factors.
     vnl_matrix<float> GetMatrix() {

--- a/lib/petpvcIntraRegRLImageFilter.h
+++ b/lib/petpvcIntraRegRLImageFilter.h
@@ -53,7 +53,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(IntraRegRLImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(IntraRegRLImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcIntraRegVCImageFilter.h
+++ b/lib/petpvcIntraRegVCImageFilter.h
@@ -53,7 +53,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(IntraRegVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(IntraRegVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcIterativeYangPVCImageFilter.h
+++ b/lib/petpvcIterativeYangPVCImageFilter.h
@@ -53,7 +53,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(IterativeYangPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(IterativeYangPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcLabbeImageFilter.h
+++ b/lib/petpvcLabbeImageFilter.h
@@ -55,7 +55,11 @@ public:
 
     itkNewMacro(Self);
 
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(LabbeImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(LabbeImageFilter);
+#endif
 
     //Returns correction factors.
     vnl_matrix<float> GetMatrix() {

--- a/lib/petpvcLabbeMTCPVCImageFilter.h
+++ b/lib/petpvcLabbeMTCPVCImageFilter.h
@@ -52,7 +52,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(LabbeMTCPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(LabbeMTCPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcLabbePVCImageFilter.h
+++ b/lib/petpvcLabbePVCImageFilter.h
@@ -50,7 +50,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(LabbePVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(LabbePVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcLabbeRBVPVCImageFilter.h
+++ b/lib/petpvcLabbeRBVPVCImageFilter.h
@@ -52,7 +52,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(LabbeRBVPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(LabbeRBVPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcMTCPVCImageFilter.h
+++ b/lib/petpvcMTCPVCImageFilter.h
@@ -52,7 +52,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(MTCPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(MTCPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcMullerGartnerImageFilter.h
+++ b/lib/petpvcMullerGartnerImageFilter.h
@@ -77,7 +77,11 @@ public:
 
     itkNewMacro(Self);
 
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(MullerGartnerImageFilter, InPlaceImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(MullerGartnerImageFilter);
+#endif
 
     //PET image
     typedef TInputImage1 Input1ImageType;

--- a/lib/petpvcRBVPVCImageFilter.h
+++ b/lib/petpvcRBVPVCImageFilter.h
@@ -51,7 +51,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(RBVPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(RBVPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcRLPVCImageFilter.h
+++ b/lib/petpvcRLPVCImageFilter.h
@@ -56,7 +56,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(RichardsonLucyPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(RichardsonLucyPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcRegionConvolutionImageFilter.h
+++ b/lib/petpvcRegionConvolutionImageFilter.h
@@ -50,7 +50,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(RegionConvolutionPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(RegionConvolutionPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcRoussetPVCImageFilter.h
+++ b/lib/petpvcRoussetPVCImageFilter.h
@@ -48,7 +48,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(RoussetPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(RoussetPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcSTCPVCImageFilter.h
+++ b/lib/petpvcSTCPVCImageFilter.h
@@ -69,7 +69,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(STCPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(STCPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;

--- a/lib/petpvcVanCittertPVCImageFilter.h
+++ b/lib/petpvcVanCittertPVCImageFilter.h
@@ -55,7 +55,11 @@ public:
     itkNewMacro(Self);
 
     /** Run-time type information (and related methods). */
+#if ITK_VERSION_MAJOR < 6
     itkTypeMacro(VanCittertPVCImageFilter, ImageToImageFilter);
+#else
+    itkOverrideGetNameOfClassMacro(VanCittertPVCImageFilter);
+#endif
 
     /** Image related typedefs. */
     typedef TInputImage             InputImageType;


### PR DESCRIPTION
Fixes #101

Also replaces all `itkTypeMacro` with `itkOverrideGetNameOfClassMacro` for ITK >= 6.0